### PR TITLE
fix(auth): recover unverified signup when email verification is enabled

### DIFF
--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -204,11 +204,21 @@ export default function LoginPage({
         {
           onError: (ctx) => {
             console.error('Login error:', ctx.error)
-            const errorMessage: string[] = ['Invalid email or password']
 
-            if (ctx.error.code?.includes('EMAIL_NOT_VERIFIED')) {
+            if (
+              ctx.error.code?.includes('EMAIL_NOT_VERIFIED') ||
+              ctx.error.message?.includes('Email not verified') ||
+              ctx.error.message?.includes('not verified')
+            ) {
+              if (typeof window !== 'undefined') {
+                sessionStorage.setItem('verificationEmail', email)
+              }
+              router.push('/verify?fromSignup=false')
+              setIsLoading(false)
               return
             }
+
+            const errorMessage: string[] = ['Invalid email or password']
             if (
               ctx.error.code?.includes('BAD_REQUEST') ||
               ctx.error.message?.includes('Email and password sign in is not enabled')

--- a/src/app/(auth)/register/register-form.tsx
+++ b/src/app/(auth)/register/register-form.tsx
@@ -18,14 +18,33 @@ const getSignUpErrorMessage = (error: { message?: string; code?: string } | null
     return 'Could not create your account. Please try again.'
   }
 
-  if (error.code === 'USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL') {
+  if (isDuplicateEmailError(error)) {
     return 'An account with this email already exists. Sign in instead, or use a different email.'
   }
 
   return error.message || 'Could not create your account. Please try again.'
 }
 
-async function tryClearUnverifiedUser(email: string): Promise<boolean> {
+function isDuplicateEmailError(error: { message?: string; code?: string } | null | undefined) {
+  if (!error) {
+    return false
+  }
+
+  const code = error.code?.toUpperCase() ?? ''
+  const message = error.message?.toLowerCase() ?? ''
+
+  return (
+    code.includes('USER_ALREADY_EXISTS') ||
+    code.includes('EMAIL_ALREADY_EXISTS') ||
+    message.includes('already exists') ||
+    message.includes('use another email')
+  )
+}
+
+type PrepareSignupEmailResult = 'ready' | 'verified_exists' | 'failed'
+
+/** Clears an abandoned unverified signup so register can proceed without a failed retry. */
+async function prepareSignupEmail(email: string): Promise<PrepareSignupEmailResult> {
   const response = await fetch('/api/auth/clear-unverified-user', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -33,11 +52,20 @@ async function tryClearUnverifiedUser(email: string): Promise<boolean> {
   })
 
   if (!response.ok) {
-    return false
+    return 'failed'
   }
 
-  const data = (await response.json()) as { canResume?: boolean }
-  return Boolean(data.canResume)
+  const data = (await response.json()) as { result?: string; canResume?: boolean }
+
+  if (data.result === 'verified_exists') {
+    return 'verified_exists'
+  }
+
+  if (data.canResume) {
+    return 'ready'
+  }
+
+  return 'failed'
 }
 
 const validateEmailField = (emailValue: string): string[] => {
@@ -190,7 +218,21 @@ export default function RegisterForm({
     }
 
     try {
-      let response = await client.signUp.email(
+      const prep = await prepareSignupEmail(emailValue)
+
+      if (prep === 'verified_exists') {
+        setSubmitError(getSignUpErrorMessage({ code: 'USER_ALREADY_EXISTS' }))
+        setIsLoading(false)
+        return
+      }
+
+      if (prep === 'failed') {
+        setSubmitError('Could not prepare signup. Please try again.')
+        setIsLoading(false)
+        return
+      }
+
+      const response = await client.signUp.email(
         {
           email: emailValue,
           password: passwordValue,
@@ -198,20 +240,6 @@ export default function RegisterForm({
         },
         {}
       )
-
-      if (
-        response?.error?.code === 'USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL' &&
-        (await tryClearUnverifiedUser(emailValue))
-      ) {
-        response = await client.signUp.email(
-          {
-            email: emailValue,
-            password: passwordValue,
-            name: nameValue,
-          },
-          {}
-        )
-      }
 
       if (!response || response.error) {
         setSubmitError(getSignUpErrorMessage(response?.error))

--- a/src/app/(auth)/register/register-form.tsx
+++ b/src/app/(auth)/register/register-form.tsx
@@ -13,6 +13,33 @@ import { cn } from '@/lib/utils'
 import { quickValidateEmail } from '@/lib/messaging/email/validation'
 import { SocialLoginButtons } from '../components/social-login-buttons'
 
+const getSignUpErrorMessage = (error: { message?: string; code?: string } | null | undefined) => {
+  if (!error) {
+    return 'Could not create your account. Please try again.'
+  }
+
+  if (error.code === 'USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL') {
+    return 'An account with this email already exists. Sign in instead, or use a different email.'
+  }
+
+  return error.message || 'Could not create your account. Please try again.'
+}
+
+async function tryClearUnverifiedUser(email: string): Promise<boolean> {
+  const response = await fetch('/api/auth/clear-unverified-user', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  })
+
+  if (!response.ok) {
+    return false
+  }
+
+  const data = (await response.json()) as { canResume?: boolean }
+  return Boolean(data.canResume)
+}
+
 const validateEmailField = (emailValue: string): string[] => {
   const errors: string[] = []
 
@@ -77,6 +104,7 @@ export default function RegisterForm({
   const [email, setEmail] = useState('')
   const [emailErrors, setEmailErrors] = useState<string[]>([])
   const [showEmailValidationError, setShowEmailValidationError] = useState(false)
+  const [submitError, setSubmitError] = useState('')
 
   const [callbackUrl, setCallbackUrl] = useState('/dashboard')
 
@@ -129,6 +157,7 @@ export default function RegisterForm({
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
     setIsLoading(true)
+    setSubmitError('')
 
     const formData = new FormData(event.currentTarget)
     const emailRaw = formData.get('email') as string
@@ -161,7 +190,7 @@ export default function RegisterForm({
     }
 
     try {
-      const response = await client.signUp.email(
+      let response = await client.signUp.email(
         {
           email: emailValue,
           password: passwordValue,
@@ -170,7 +199,22 @@ export default function RegisterForm({
         {}
       )
 
+      if (
+        response?.error?.code === 'USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL' &&
+        (await tryClearUnverifiedUser(emailValue))
+      ) {
+        response = await client.signUp.email(
+          {
+            email: emailValue,
+            password: passwordValue,
+            name: nameValue,
+          },
+          {}
+        )
+      }
+
       if (!response || response.error) {
+        setSubmitError(getSignUpErrorMessage(response?.error))
         setIsLoading(false)
         return
       }
@@ -182,6 +226,7 @@ export default function RegisterForm({
       router.push('/verify?fromSignup=true')
     } catch (error) {
       console.error('Signup error:', error)
+      setSubmitError('Could not create your account. Please try again.')
     } finally {
       setIsLoading(false)
     }
@@ -301,6 +346,17 @@ export default function RegisterForm({
             )}
           </div>
         </div>
+
+        {submitError ? (
+          <p className='text-center text-sm text-red-400' role='alert'>
+            {submitError}{' '}
+            {submitError.includes('already exists') ? (
+              <Link href='/login' className='underline underline-offset-2'>
+                Sign in
+              </Link>
+            ) : null}
+          </p>
+        ) : null}
 
         <Button
           type='submit'

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,6 +1,7 @@
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth/auth'
+import { isEmailVerificationEnabled } from '@/config/feature-flags'
 
 export default async function MainLayout({ children }: { children: React.ReactNode }) {
   const session = await auth.api.getSession({
@@ -9,6 +10,10 @@ export default async function MainLayout({ children }: { children: React.ReactNo
 
   if (!session) {
     redirect('/login')
+  }
+
+  if (isEmailVerificationEnabled && !session.user.emailVerified) {
+    redirect('/verify?redirectAfter=/dashboard')
   }
 
   return <>{children}</>

--- a/src/app/api/auth/clear-unverified-user/route.ts
+++ b/src/app/api/auth/clear-unverified-user/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+
+import { clearUnverifiedUserByEmail } from '@/lib/auth/unverified-signup'
+
+export async function POST(request: Request) {
+  let body: { email?: string }
+
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const email = body.email?.trim().toLowerCase()
+
+  if (!email) {
+    return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+  }
+
+  const result = await clearUnverifiedUserByEmail(email)
+
+  return NextResponse.json({
+    result,
+    canResume: result === 'deleted' || result === 'not_found',
+  })
+}

--- a/src/lib/auth/auth-client.ts
+++ b/src/lib/auth/auth-client.ts
@@ -18,8 +18,26 @@ export const client = createAuthClient({
   baseURL: getBaseUrl(),
   plugins: [emailOTPClient(), organizationClient()],
   fetchOptions: {
-    onError(error) {
-      console.error('Auth error:', error)
+    onError(context) {
+      const message =
+        context.error?.message ||
+        (typeof context.error?.status === 'number'
+          ? `Request failed (${context.error.status})`
+          : 'Authentication request failed')
+
+      const code = context.error?.code?.toUpperCase() ?? ''
+      const normalizedMessage = message.toLowerCase()
+      const isDuplicateEmail =
+        code.includes('USER_ALREADY_EXISTS') ||
+        code.includes('EMAIL_ALREADY_EXISTS') ||
+        normalizedMessage.includes('already exists') ||
+        normalizedMessage.includes('use another email')
+
+      if (isDuplicateEmail) {
+        return
+      }
+
+      console.error('Auth error:', message, context.error)
     },
     onSuccess(data) {
       console.log('Auth action successful:', data)

--- a/src/lib/auth/unverified-signup.ts
+++ b/src/lib/auth/unverified-signup.ts
@@ -1,0 +1,34 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/database'
+import { user } from '@/database/schema'
+
+export type ClearUnverifiedUserResult = 'deleted' | 'verified_exists' | 'not_found'
+
+/**
+ * Removes an unverified user so signup can be retried after a failed OTP flow.
+ * Sessions and credential accounts cascade from the user row.
+ */
+export async function clearUnverifiedUserByEmail(
+  email: string
+): Promise<ClearUnverifiedUserResult> {
+  const normalizedEmail = email.trim().toLowerCase()
+
+  const [existing] = await db
+    .select({ id: user.id, emailVerified: user.emailVerified })
+    .from(user)
+    .where(eq(user.email, normalizedEmail))
+    .limit(1)
+
+  if (!existing) {
+    return 'not_found'
+  }
+
+  if (existing.emailVerified) {
+    return 'verified_exists'
+  }
+
+  await db.delete(user).where(eq(user.id, existing.id))
+
+  return 'deleted'
+}


### PR DESCRIPTION
## Summary

Fixes a dead-end UX when `EMAIL_VERIFICATION_ENABLED=true` and OTP verification is incomplete or fails.

Closes #42

## Problem

Signup creates a user immediately (`sendVerificationOnSignUp: false`), but login is blocked until verified. If OTP fails or the user abandons `/verify`, the email cannot be reused and login shows no helpful path forward.

## Changes

- **`src/lib/auth/unverified-signup.ts`** — delete unverified user by email (verified accounts untouched; FK cascades handle sessions/accounts)
- **`src/app/api/auth/clear-unverified-user/route.ts`** — API used by register resume flow
- **`register-form.tsx`** — show signup errors; clear unverified user **before** signup (avoids duplicate-email console noise); handle verified vs unverified duplicate paths
- **`login-form.tsx`** — redirect to `/verify` on `EMAIL_NOT_VERIFIED` instead of silent return
- **`auth-client.ts`** — skip global console error for expected duplicate-email responses (handled in UI)
- **`(main)/layout.tsx`** — redirect unverified users to `/verify` when verification is enabled


### Setup

```bash
bun install
cp .env.example .env
# set DATABASE_URL, then:
bun run migrate:local
```

In `.env`:

```
EMAIL_VERIFICATION_ENABLED=true
EMAIL_PROVIDER=log
```

```bash
bun dev
```

### Repro

1. Go to `/register` → sign up with a new email + password
2. Land on `/verify` → **do not** enter OTP; navigate away
3. Go to `/register` again with the **same email** → stuck / error (cannot resume cleanly on `main`)
4. Go to `/login` with same credentials → blocked; no redirect to `/verify` on `main`
5. DB: `user.email_verified = false` for that email until manual delete

## Changes

- **`src/lib/auth/unverified-signup.ts`** — delete unverified user by email (verified accounts untouched; FK cascades handle sessions/accounts)
- **`src/app/api/auth/clear-unverified-user/route.ts`** — API used by register resume flow
- **`register-form.tsx`** — show signup errors; clear unverified user **before** signup (avoids duplicate-email console noise); handle verified vs unverified duplicate paths
- **`login-form.tsx`** — redirect to `/verify` on `EMAIL_NOT_VERIFIED` instead of silent return
- **`auth-client.ts`** — skip global console error for expected duplicate-email responses (handled in UI)
- **`(main)/layout.tsx`** — redirect unverified users to `/verify` when verification is enabled

## Test plan (after this PR)

Use the same setup as **How to reproduce** (`EMAIL_VERIFICATION_ENABLED=true`, `EMAIL_PROVIDER=log`).

- [ ] Register → abandon `/verify` → register again with same email → reaches `/verify`, no console "User already exists" error
- [ ] Register → abandon → login with same credentials → redirects to `/verify`
- [ ] Enter OTP from terminal log → login and `/dashboard` work
- [ ] Register + verify email A → attempt register with A again → shows “already exists” (verified user not deleted)
- [ ] With `EMAIL_VERIFICATION_ENABLED=false`, behavior unchanged

## Notes

No breaking API changes. The clear endpoint only removes users where `email_verified = false`.

