### PR TITLE
fix(auth): guard verify page and correct signup OTP flow

### DIFF
--- a/src/app/(auth)/verify/page.tsx
+++ b/src/app/(auth)/verify/page.tsx
@@ -1,6 +1,10 @@
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { auth } from '@/lib/auth/auth'
 import { isProd } from '@/lib/constants'
-import { VerifyContent } from './verify-content'
 import { generateMetadata } from '@/lib/seo'
+import { VerifyContent } from './verify-content'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,6 +12,16 @@ export const metadata = generateMetadata({
   title: 'Verification | ShipFree',
 })
 
-export default function VerifyPage() {
-  return <VerifyContent isProduction={isProd} />
+export default async function VerifyPage() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  })
+
+  if (session?.user.emailVerified) {
+    redirect('/dashboard')
+  }
+
+  return (
+    <VerifyContent isProduction={isProd} initialEmail={session?.user.email ?? null} />
+  )
 }

--- a/src/app/(auth)/verify/use-verification.ts
+++ b/src/app/(auth)/verify/use-verification.ts
@@ -7,6 +7,7 @@ import { client, useSession } from '@/lib/auth/auth-client'
 
 interface UseVerificationParams {
   isProduction: boolean
+  initialEmail?: string | null
 }
 
 interface UseVerificationReturn {
@@ -18,15 +19,21 @@ interface UseVerificationReturn {
   errorMessage: string
   isOtpComplete: boolean
   isProduction: boolean
+  isContextReady: boolean
   verifyCode: () => Promise<void>
   resendCode: () => void
   handleOtpChange: (value: string) => void
 }
 
-export function useVerification({ isProduction }: UseVerificationParams): UseVerificationReturn {
+const getOtpType = (fromSignup: boolean) => (fromSignup ? 'email-verification' : 'sign-in')
+
+export function useVerification({
+  isProduction,
+  initialEmail = null,
+}: UseVerificationParams): UseVerificationReturn {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { refetch: refetchSession } = useSession()
+  const { data: session, isPending: isSessionPending, refetch: refetchSession } = useSession()
   const [otp, setOtp] = useState('')
   const [email, setEmail] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -35,18 +42,16 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
   const [isInvalidOtp, setIsInvalidOtp] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null)
+  const [isContextReady, setIsContextReady] = useState(false)
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const storedEmail = sessionStorage.getItem('verificationEmail')
-      if (storedEmail) {
-        setEmail(storedEmail)
-      }
+    if (typeof window === 'undefined') {
+      return
+    }
 
-      const storedRedirectUrl = sessionStorage.getItem('inviteRedirectUrl')
-      if (storedRedirectUrl) {
-        setRedirectUrl(storedRedirectUrl)
-      }
+    const storedRedirectUrl = sessionStorage.getItem('inviteRedirectUrl')
+    if (storedRedirectUrl) {
+      setRedirectUrl(storedRedirectUrl)
     }
 
     const redirectParam = searchParams.get('redirectAfter')
@@ -56,10 +61,58 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
   }, [searchParams])
 
   useEffect(() => {
-    if (email && !isSendingInitialOtp) {
-      setIsSendingInitialOtp(true)
+    if (isSessionPending) {
+      return
     }
-  }, [email, isSendingInitialOtp])
+
+    if (session?.user.emailVerified) {
+      window.location.href = '/dashboard'
+      return
+    }
+
+    const storedEmail = sessionStorage.getItem('verificationEmail')?.trim().toLowerCase() ?? ''
+    const sessionEmail = session?.user.email?.trim().toLowerCase() ?? ''
+    const serverEmail = initialEmail?.trim().toLowerCase() ?? ''
+    const resolvedEmail = storedEmail || sessionEmail || serverEmail
+
+    if (!resolvedEmail) {
+      router.replace('/register')
+      return
+    }
+
+    setEmail(resolvedEmail)
+
+    if (!storedEmail) {
+      sessionStorage.setItem('verificationEmail', resolvedEmail)
+    }
+
+    setIsContextReady(true)
+  }, [initialEmail, isSessionPending, router, session])
+
+  useEffect(() => {
+    const fromSignup = searchParams.get('fromSignup') === 'true'
+
+    if (!isContextReady || !email || isSendingInitialOtp) {
+      return
+    }
+
+    setIsSendingInitialOtp(true)
+    setIsLoading(true)
+    setErrorMessage('')
+
+    const normalizedEmail = email.trim().toLowerCase()
+    client.emailOtp
+      .sendVerificationOtp({
+        email: normalizedEmail,
+        type: getOtpType(fromSignup),
+      })
+      .catch(() => {
+        setErrorMessage('Failed to send verification code. Check email settings and try Resend.')
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }, [email, isContextReady, isSendingInitialOtp, searchParams])
 
   const isOtpComplete = otp.length === 6
 
@@ -72,10 +125,17 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
 
     try {
       const normalizedEmail = email.trim().toLowerCase()
-      const response = await client.signIn.emailOtp({
-        email: normalizedEmail,
-        otp,
-      })
+      const fromSignup = searchParams.get('fromSignup') === 'true'
+
+      const response = fromSignup
+        ? await client.emailOtp.verifyEmail({
+            email: normalizedEmail,
+            otp,
+          })
+        : await client.signIn.emailOtp({
+            email: normalizedEmail,
+            otp,
+          })
 
       if (response && !response.error) {
         setIsVerified(true)
@@ -86,6 +146,10 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
           console.warn('Failed to refetch session after verification', e)
         }
 
+        if (typeof window !== 'undefined') {
+          sessionStorage.removeItem('verificationEmail')
+        }
+
         setTimeout(() => {
           if (redirectUrl) {
             window.location.href = redirectUrl
@@ -94,35 +158,26 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
           }
         }, 1000)
       } else {
-        console.info('Setting invalid OTP state - API error response')
         const message = 'Invalid verification code. Please check and try again.'
         setIsInvalidOtp(true)
         setErrorMessage(message)
-        console.info('Error state after API error:', {
-          isInvalidOtp: true,
-          errorMessage: message,
-        })
         setOtp('')
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       let message = 'Verification failed. Please check your code and try again.'
+      const errorMessageText =
+        error instanceof Error ? error.message : typeof error === 'string' ? error : ''
 
-      if (error.message?.includes('expired')) {
+      if (errorMessageText.includes('expired')) {
         message = 'The verification code has expired. Please request a new one.'
-      } else if (error.message?.includes('invalid')) {
-        console.info('Setting invalid OTP state - caught error')
+      } else if (errorMessageText.includes('invalid')) {
         message = 'Invalid verification code. Please check and try again.'
-      } else if (error.message?.includes('attempts')) {
+      } else if (errorMessageText.includes('attempts')) {
         message = 'Too many failed attempts. Please request a new code.'
       }
 
       setIsInvalidOtp(true)
       setErrorMessage(message)
-      console.info('Error state after caught error:', {
-        isInvalidOtp: true,
-        errorMessage: message,
-      })
-
       setOtp('')
     } finally {
       setIsLoading(false)
@@ -136,12 +191,13 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
     setErrorMessage('')
 
     const normalizedEmail = email.trim().toLowerCase()
+    const fromSignup = searchParams.get('fromSignup') === 'true'
+
     client.emailOtp
       .sendVerificationOtp({
         email: normalizedEmail,
-        type: 'sign-in',
+        type: getOtpType(fromSignup),
       })
-      .then(() => {})
       .catch(() => {
         setErrorMessage('Failed to resend verification code. Please try again later.')
       })
@@ -159,14 +215,14 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
   }
 
   useEffect(() => {
-    if (otp.length === 6 && email && !isLoading && !isVerified) {
+    if (otp.length === 6 && email && !isLoading && !isVerified && isContextReady) {
       const timeoutId = setTimeout(() => {
-        verifyCode()
+        void verifyCode()
       }, 300)
 
       return () => clearTimeout(timeoutId)
     }
-  }, [otp, email, isLoading, isVerified])
+  }, [otp, email, isLoading, isVerified, isContextReady])
 
   return {
     otp,
@@ -177,6 +233,7 @@ export function useVerification({ isProduction }: UseVerificationParams): UseVer
     errorMessage,
     isOtpComplete,
     isProduction,
+    isContextReady,
     verifyCode,
     resendCode,
     handleOtpChange,

--- a/src/app/(auth)/verify/verify-content.tsx
+++ b/src/app/(auth)/verify/verify-content.tsx
@@ -10,9 +10,16 @@ import { useVerification } from './use-verification'
 
 interface VerifyContentProps {
   isProduction: boolean
+  initialEmail?: string | null
 }
 
-function VerificationForm({ isProduction }: { isProduction: boolean }) {
+function VerificationForm({
+  isProduction,
+  initialEmail = null,
+}: {
+  isProduction: boolean
+  initialEmail?: string | null
+}) {
   const {
     otp,
     email,
@@ -21,10 +28,11 @@ function VerificationForm({ isProduction }: { isProduction: boolean }) {
     isInvalidOtp,
     errorMessage,
     isOtpComplete,
+    isContextReady,
     verifyCode,
     resendCode,
     handleOtpChange,
-  } = useVerification({ isProduction })
+  } = useVerification({ isProduction, initialEmail })
 
   const [countdown, setCountdown] = useState(0)
   const [isResendDisabled, setIsResendDisabled] = useState(false)
@@ -47,6 +55,17 @@ function VerificationForm({ isProduction }: { isProduction: boolean }) {
     setCountdown(30)
   }
 
+  if (!isContextReady) {
+    return (
+      <div className='text-center'>
+        <div className='animate-pulse'>
+          <div className='mx-auto mb-4 h-8 w-48 rounded bg-gray-200' />
+          <div className='mx-auto h-4 w-64 rounded bg-gray-200' />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <>
       <div className='space-y-1 text-center'>
@@ -56,7 +75,7 @@ function VerificationForm({ isProduction }: { isProduction: boolean }) {
         <p className='font-[380] text-[16px] text-muted-foreground'>
           {isVerified
             ? 'Your email has been verified. Redirecting to dashboard...'
-            : `A verification code has been sent to ${email || 'your email'}`}
+            : `A verification code has been sent to ${email}`}
         </p>
       </div>
 
@@ -177,7 +196,7 @@ function VerificationForm({ isProduction }: { isProduction: boolean }) {
                   sessionStorage.removeItem('inviteRedirectUrl')
                   sessionStorage.removeItem('isInviteFlow')
                 }
-                router.push('/signup')
+                router.push('/register')
               }}
               className='font-medium text-(--brand-accent-hex) underline-offset-4 transition hover:text-(--brand-accent-hover-hex) hover:underline'
             >
@@ -201,10 +220,10 @@ function VerificationFormFallback() {
   )
 }
 
-export function VerifyContent({ isProduction }: VerifyContentProps) {
+export function VerifyContent({ isProduction, initialEmail = null }: VerifyContentProps) {
   return (
     <Suspense fallback={<VerificationFormFallback />}>
-      <VerificationForm isProduction={isProduction} />
+      <VerificationForm isProduction={isProduction} initialEmail={initialEmail} />
     </Suspense>
   )
 }

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -14,6 +14,7 @@ import {
   renderWelcomeEmail,
 } from '@/components/emails'
 import { getFromEmailAddress, quickValidateEmail, sendEmail } from '@/lib/messaging/email'
+import { getActiveProviderName } from '@/lib/messaging/email/mailer'
 import { isEmailVerificationEnabled } from '@/config/feature-flags'
 
 export const auth = betterAuth({
@@ -26,10 +27,10 @@ export const auth = betterAuth({
   advanced: {
     cookiePrefix: APP_COOKIE_NAME, // Change this to your cookie prefix
     crossSubDomainCookies: {
-      enabled: !isProd,
+      enabled: isProd,
       domain: '.shipfree.app', // Change this to your domain, if you are using a custom domain
     },
-    useSecureCookies: !isProd,
+    useSecureCookies: isProd,
   },
 
   session: {
@@ -161,13 +162,21 @@ export const auth = betterAuth({
             emailType: 'transactional',
           })
 
-          if (!result.success && result.message.includes('no email service configured')) {
+          const otpWasLoggedOnly =
+            getActiveProviderName() === 'log' ||
+            result.message.toLowerCase().includes('logged')
+
+          if (!isProd || otpWasLoggedOnly) {
             console.info('🔑 VERIFICATION CODE FOR LOGIN/SIGNUP', {
               email: data.email,
               otp: data.otp,
               type: data.type,
+              provider: getActiveProviderName(),
               validation: validation.checks,
             })
+          }
+
+          if (!result.success && result.message.includes('no email service configured')) {
             return
           }
 


### PR DESCRIPTION
## Summary

- **Cold `/verify?fromSignup=true`:** redirect to `/register` when there is no `verificationEmail` in sessionStorage and no session email (fixes empty “sent to your email” dead-end).
- **Signup OTP:** auto-send `email-verification` OTP on mount; resend uses the same type from `fromSignup`.
- **Verify API:** use `client.emailOtp.verifyEmail()` for signup, not `client.signIn.emailOtp()`.
- **Already verified:** server redirect to `/dashboard` when `emailVerified` is true.
- **UX:** loading state until context is ready; “Back to signup” links to `/register` (not `/signup`).
- **Local dev (auth.ts):** fix inverted `useSecureCookies` / `crossSubDomainCookies`; log OTP to console when `EMAIL_PROVIDER=log` (matches docs).

## Test plan

Manual (port 3002, `EMAIL_PROVIDER=log`, Postgres `shipfree` DB):

1. New tab → `http://localhost:3002/verify?fromSignup=true` → must land on `/register`.
2. Register → `/verify?fromSignup=true` shows your email; terminal logs `🔑 VERIFICATION CODE` with `type: email-verification`.
3. Enter OTP → `/dashboard` with session cookies set.

Automated check used Playwright against the above (all passed on `fix/verify-page-guards`).

## Related

Separate branch `fix/unverified-email-recovery` — do not merge into this PR.

Upstream issue body: `ISSUE-verify-page.md` in `shipfree-contribution/`.
