### PR TITLE
feat(payments): add Creem.io as a payment provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,7 +132,7 @@ NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn
 # OPTIONAL: PAYMENT PROVIDERS
 # -----------------------------------------------------------------------------
 # Configure payment providers for your application's billing/subscription features
-# Choose one: stripe, polar, or lemonsqueezy
+# Choose one: stripe, polar, lemonsqueezy, or creem
 # PAYMENT_PROVIDER=stripe
 
 # ----- STRIPE (for application payments) -----
@@ -172,6 +172,19 @@ NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn
 # NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_STARTER_MONTHLY=prod_...
 # NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_PRO_MONTHLY=prod_...
 # NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_ENTERPRISE_MONTHLY=prod_...
+
+# ----- CREEM -----
+# EU-based Merchant of Record. Get credentials from: https://creem.io (Developers menu)
+# NOTE: test mode and production use DIFFERENT API keys.
+# CREEM_API_KEY=creem_...
+# CREEM_WEBHOOK_SECRET=whsec_...
+# Set to true to target test-api.creem.io with your test-mode key
+# CREEM_TEST_MODE=false
+
+# Public Creem product IDs
+# NEXT_PUBLIC_CREEM_PRODUCT_STARTER_MONTHLY=prod_...
+# NEXT_PUBLIC_CREEM_PRODUCT_PRO_MONTHLY=prod_...
+# NEXT_PUBLIC_CREEM_PRODUCT_ENTERPRISE_MONTHLY=prod_...
 
 # =============================================================================
 # OPTIONAL: PREMIUM TEMPLATE PURCHASE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ ShipFree is a production-ready Next.js boilerplate designed to help developers s
 - **Runtime**: Bun (package manager and runtime)
 - **Database**: PostgreSQL with Drizzle ORM
 - **Authentication**: Better-Auth with multiple OAuth providers
-- **Payments**: Multi-provider support (Stripe, Polar, Lemon Squeezy)
+- **Payments**: Multi-provider support (Stripe, Polar, Lemon Squeezy, Creem)
 - **Email**: Multi-provider support (Resend, Postmark, Plunk, Nodemailer)
 - **UI**: TailwindCSS 4, BaseUI components, Shadcn-style patterns
 - **Internationalization**: next-intl (i18n) with support for en, es, fr

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ ShipFree is a production-ready Next.js boilerplate designed to help developers s
 - **Runtime**: Bun (package manager and runtime)
 - **Database**: PostgreSQL with Drizzle ORM
 - **Authentication**: Better-Auth with multiple OAuth providers
-- **Payments**: Multi-provider support (Stripe, Polar, Lemon Squeezy)
+- **Payments**: Multi-provider support (Stripe, Polar, Lemon Squeezy, Creem)
 - **Email**: Multi-provider support (Resend, Postmark, Plunk, Nodemailer)
 - **UI**: TailwindCSS 4, BaseUI components, Shadcn-style patterns
 - **Internationalization**: next-intl (i18n) with support for en, es, fr

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The premium purchase feature is used to sell the Premium template itself ($90 on
 - Discord invite link display after purchase
 - Client-side purchase tracking via localStorage
 
-**Important:** This is separate from the template's built-in payment system (Stripe, Polar, Lemon Squeezy) which is used by your application to accept payments from your customers.
+**Important:** This is separate from the template's built-in payment system (Stripe, Polar, Lemon Squeezy, Creem) which is used by your application to accept payments from your customers.
 
 ### How to Remove
 

--- a/docs/environment.mdx
+++ b/docs/environment.mdx
@@ -36,10 +36,11 @@ Set these to start the app locally:
 
 ### Payments
 
-- `PAYMENT_PROVIDER` (`stripe`, `polar`, `lemonsqueezy`)
+- `PAYMENT_PROVIDER` (`stripe`, `polar`, `lemonsqueezy`, `creem`)
 - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID`
 - `POLAR_ACCESS_TOKEN`, `POLAR_WEBHOOK_SECRET`, `POLAR_ORGANIZATION_ID`, `POLAR_PRODUCT_ID`
 - `LEMONSQUEEZY_API_KEY`, `LEMONSQUEEZY_STORE_ID`, `LEMONSQUEEZY_WEBHOOK_SECRET`
+- `CREEM_API_KEY`, `CREEM_WEBHOOK_SECRET`, `CREEM_TEST_MODE`
 
 ### Storage
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,7 +15,7 @@ ShipFree is a production-ready Next.js template that ships the boring parts for 
 
 - Next.js App Router with server components by default
 - Better-Auth with email OTP and social providers
-- Payments with Stripe, Polar, and Lemon Squeezy adapters
+- Payments with Stripe, Polar, Lemon Squeezy, and Creem adapters
 - Email delivery with Resend, Postmark, Plunk, SMTP, or a custom provider
 - Cloudflare R2 storage client
 - Sentry instrumentation hooks

--- a/docs/payments/providers.mdx
+++ b/docs/payments/providers.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Payment Providers"
-description: "Stripe, Polar, and Lemon Squeezy configuration."
+description: "Stripe, Polar, Lemon Squeezy, and Creem configuration."
 ---
 
 # Payment providers
 
-ShipFree ships with Stripe, Polar, and Lemon Squeezy adapters. Configure one provider and set `PAYMENT_PROVIDER`.
+ShipFree ships with Stripe, Polar, Lemon Squeezy, and Creem adapters. Configure one provider and set `PAYMENT_PROVIDER` (`stripe`, `polar`, `lemonsqueezy`, or `creem`).
 
 ## Stripe
 
@@ -52,6 +52,30 @@ Optional public product IDs:
 - `NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_STARTER_MONTHLY`
 - `NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_PRO_MONTHLY`
 - `NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_ENTERPRISE_MONTHLY`
+
+## Creem
+
+[Creem](https://creem.io) is an EU-based Merchant of Record with low fees. Get your API key from the dashboard under the **Developers** menu.
+
+<Note>
+  Creem uses **different API keys** for test mode and production. Set `CREEM_TEST_MODE=true`
+  to target `test-api.creem.io` with your test-mode key.
+</Note>
+
+Required:
+
+- `CREEM_API_KEY`
+- `CREEM_WEBHOOK_SECRET`
+
+Optional:
+
+- `CREEM_TEST_MODE` (`true` to use the Creem test environment)
+
+Optional public product IDs:
+
+- `NEXT_PUBLIC_CREEM_PRODUCT_STARTER_MONTHLY`
+- `NEXT_PUBLIC_CREEM_PRODUCT_PRO_MONTHLY`
+- `NEXT_PUBLIC_CREEM_PRODUCT_ENTERPRISE_MONTHLY`
 
 <Warning>
   If the configured provider is missing credentials, the payment system will fail at runtime.

--- a/docs/payments/webhooks.mdx
+++ b/docs/payments/webhooks.mdx
@@ -16,6 +16,7 @@ The handler verifies the signature for the active provider and uses the adapter 
 - Stripe uses the `stripe-signature` header
 - Polar uses the `polar-webhook-signature` header
 - Lemon Squeezy uses the `x-signature` header
+- Creem uses the `creem-signature` header (HMAC-SHA256 of the raw body with `CREEM_WEBHOOK_SECRET`)
 
 ## Local development
 

--- a/src/app/api/webhooks/payments/route.ts
+++ b/src/app/api/webhooks/payments/route.ts
@@ -29,6 +29,9 @@ export async function POST(req: Request) {
       case 'lemonsqueezy':
         signature = headerList.get('x-signature') || ''
         break
+      case 'creem':
+        signature = headerList.get('creem-signature') || ''
+        break
     }
 
     if (!signature) {
@@ -62,6 +65,9 @@ export async function POST(req: Request) {
       } else if (provider === 'lemonsqueezy') {
         // Lemon Squeezy event name is in meta.event_name
         type = parsedBody.meta?.event_name
+      } else if (provider === 'creem') {
+        // Creem event name is in eventType
+        type = parsedBody.eventType
       }
 
       if (!type) {
@@ -73,7 +79,7 @@ export async function POST(req: Request) {
         type: type as WebhookEvent['type'],
         provider,
         data:
-          provider === 'lemonsqueezy'
+          provider === 'lemonsqueezy' || provider === 'creem'
             ? parsedBody
             : parsedBody.data?.object || parsedBody.data || parsedBody,
         rawEvent: parsedBody,

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -39,7 +39,7 @@ export const env = createEnv({
     DEFAULT_FROM_NAME: z.string().optional(),
 
     // Optional: Payment provider selection
-    PAYMENT_PROVIDER: z.enum(['stripe', 'polar', 'lemonsqueezy']).default('stripe'),
+    PAYMENT_PROVIDER: z.enum(['stripe', 'polar', 'lemonsqueezy', 'creem']).default('stripe'),
 
     // Stripe
     STRIPE_SECRET_KEY: z.string().optional(),
@@ -57,6 +57,12 @@ export const env = createEnv({
     LEMONSQUEEZY_API_KEY: z.string().optional(),
     LEMONSQUEEZY_STORE_ID: z.string().optional(),
     LEMONSQUEEZY_WEBHOOK_SECRET: z.string().optional(),
+
+    // Creem (https://creem.io) - EU-based Merchant of Record
+    CREEM_API_KEY: z.string().optional(),
+    CREEM_WEBHOOK_SECRET: z.string().optional(),
+    // Creem ships separate test/production API keys; set this to use test-api.creem.io
+    CREEM_TEST_MODE: z.string().optional(),
 
     // Optional: OAuth
     GOOGLE_CLIENT_ID: z.string().optional(),
@@ -95,6 +101,11 @@ export const env = createEnv({
     NEXT_PUBLIC_POLAR_PRODUCT_STARTER_MONTHLY: z.string().optional(),
     NEXT_PUBLIC_POLAR_PRODUCT_PRO_MONTHLY: z.string().optional(),
     NEXT_PUBLIC_POLAR_PRODUCT_ENTERPRISE_MONTHLY: z.string().optional(),
+
+    // Creem product IDs (public)
+    NEXT_PUBLIC_CREEM_PRODUCT_STARTER_MONTHLY: z.string().optional(),
+    NEXT_PUBLIC_CREEM_PRODUCT_PRO_MONTHLY: z.string().optional(),
+    NEXT_PUBLIC_CREEM_PRODUCT_ENTERPRISE_MONTHLY: z.string().optional(),
 
     // Premium Template Purchase (public)
     NEXT_PUBLIC_PREMIUM_PURCHASE_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
@@ -157,6 +168,9 @@ export const env = createEnv({
     LEMONSQUEEZY_API_KEY: process.env.LEMONSQUEEZY_API_KEY,
     LEMONSQUEEZY_STORE_ID: process.env.LEMONSQUEEZY_STORE_ID,
     LEMONSQUEEZY_WEBHOOK_SECRET: process.env.LEMONSQUEEZY_WEBHOOK_SECRET,
+    CREEM_API_KEY: process.env.CREEM_API_KEY,
+    CREEM_WEBHOOK_SECRET: process.env.CREEM_WEBHOOK_SECRET,
+    CREEM_TEST_MODE: process.env.CREEM_TEST_MODE,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
     NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_STARTER_MONTHLY:
       process.env.NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_STARTER_MONTHLY,
@@ -177,6 +191,11 @@ export const env = createEnv({
     NEXT_PUBLIC_POLAR_PRODUCT_PRO_MONTHLY: process.env.NEXT_PUBLIC_POLAR_PRODUCT_PRO_MONTHLY,
     NEXT_PUBLIC_POLAR_PRODUCT_ENTERPRISE_MONTHLY:
       process.env.NEXT_PUBLIC_POLAR_PRODUCT_ENTERPRISE_MONTHLY,
+    NEXT_PUBLIC_CREEM_PRODUCT_STARTER_MONTHLY:
+      process.env.NEXT_PUBLIC_CREEM_PRODUCT_STARTER_MONTHLY,
+    NEXT_PUBLIC_CREEM_PRODUCT_PRO_MONTHLY: process.env.NEXT_PUBLIC_CREEM_PRODUCT_PRO_MONTHLY,
+    NEXT_PUBLIC_CREEM_PRODUCT_ENTERPRISE_MONTHLY:
+      process.env.NEXT_PUBLIC_CREEM_PRODUCT_ENTERPRISE_MONTHLY,
     NEXT_PUBLIC_PREMIUM_PURCHASE_STRIPE_PUBLISHABLE_KEY:
       process.env.NEXT_PUBLIC_PREMIUM_PURCHASE_STRIPE_PUBLISHABLE_KEY,
     NEXT_PUBLIC_PREMIUM_PURCHASE_DISCORD_INVITE_LINK:

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -40,5 +40,8 @@ export const isStripeConfigured = Boolean(env.STRIPE_SECRET_KEY && env.STRIPE_WE
 /** Check if Polar is configured (@polar-sh/better-auth) */
 export const isPolarConfigured = Boolean(env.POLAR_ACCESS_TOKEN)
 
+/** Check if Creem is configured (@creem_io/better-auth) */
+export const isCreemConfigured = Boolean(env.CREEM_API_KEY)
+
 /** Check if any billing provider is configured */
-export const hasBillingProvider = isStripeConfigured || isPolarConfigured
+export const hasBillingProvider = isStripeConfigured || isPolarConfigured || isCreemConfigured

--- a/src/config/payments.ts
+++ b/src/config/payments.ts
@@ -6,7 +6,7 @@
  */
 
 export type PlanName = 'free' | 'starter' | 'pro' | 'enterprise'
-export type PaymentProvider = 'stripe' | 'polar' | 'lemonsqueezy'
+export type PaymentProvider = 'stripe' | 'polar' | 'lemonsqueezy' | 'creem'
 export type Interval = 'month' | 'year' | null // null for one-time payments
 
 export interface PriceConfig {
@@ -104,6 +104,17 @@ export const paymentConfig = {
             type: 'recurring' as const,
           },
         ],
+        creem: [
+          {
+            productId: process.env.NEXT_PUBLIC_CREEM_PRODUCT_STARTER_MONTHLY || '',
+            interval: 'month' as const,
+            amount: 990,
+            currency: 'usd',
+            seatBased: false,
+            trialPeriodDays: 14,
+            type: 'recurring' as const,
+          },
+        ],
       },
       features: [
         'Up to 10 projects',
@@ -153,6 +164,17 @@ export const paymentConfig = {
         lemonsqueezy: [
           {
             productId: process.env.NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_PRO_MONTHLY || '',
+            interval: 'month' as const,
+            amount: 2990,
+            currency: 'usd',
+            seatBased: true,
+            trialPeriodDays: 14,
+            type: 'recurring' as const,
+          },
+        ],
+        creem: [
+          {
+            productId: process.env.NEXT_PUBLIC_CREEM_PRODUCT_PRO_MONTHLY || '',
             interval: 'month' as const,
             amount: 2990,
             currency: 'usd',
@@ -212,6 +234,17 @@ export const paymentConfig = {
         lemonsqueezy: [
           {
             productId: process.env.NEXT_PUBLIC_LEMONSQUEEZY_PRODUCT_ENTERPRISE_MONTHLY || '',
+            interval: 'month' as const,
+            amount: 9990,
+            currency: 'usd',
+            seatBased: true,
+            trialPeriodDays: 30,
+            type: 'recurring' as const,
+          },
+        ],
+        creem: [
+          {
+            productId: process.env.NEXT_PUBLIC_CREEM_PRODUCT_ENTERPRISE_MONTHLY || '',
             interval: 'month' as const,
             amount: 9990,
             currency: 'usd',

--- a/src/lib/payments/providers/creem.ts
+++ b/src/lib/payments/providers/creem.ts
@@ -1,0 +1,322 @@
+/**
+ * Creem Payment Adapter
+ *
+ * Implements the PaymentAdapter interface for Creem (https://creem.io) integration.
+ * Creem is an EU-based Merchant of Record. Handles checkout sessions, subscriptions,
+ * the customer portal, and webhooks.
+ *
+ * Dependency: creem
+ */
+
+import crypto from 'crypto'
+
+import { Creem } from 'creem'
+import type {
+  PaymentAdapter,
+  CheckoutOptions,
+  CheckoutResult,
+  CustomerData,
+  SubscriptionData,
+  PortalResult,
+  WebhookEvent,
+  WebhookResult,
+} from '../types'
+import type { PaymentProvider, PlanName } from '@/config/payments'
+import { getPriceConfig, paymentConfig } from '@/config/payments'
+import { env, isTruthy } from '@/config/env'
+
+/**
+ * Creem expands nested objects (customer, product, subscription, order) in both
+ * API responses and webhook payloads, but a field can still arrive as a bare id
+ * string. This narrows either shape down to its id.
+ */
+function resolveId(value: unknown): string {
+  if (!value) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'object' && 'id' in (value as Record<string, unknown>)) {
+    return String((value as { id: unknown }).id ?? '')
+  }
+  return ''
+}
+
+function toDate(value: unknown): Date | null {
+  if (!value) return null
+  const date = new Date(value as string)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export class CreemAdapter implements PaymentAdapter {
+  public readonly provider: PaymentProvider = 'creem'
+  private creem: Creem
+  private apiKey: string
+
+  constructor() {
+    if (!env.CREEM_API_KEY) {
+      throw new Error('CREEM_API_KEY is required for Creem adapter')
+    }
+
+    this.apiKey = env.CREEM_API_KEY
+    // serverIdx 0 -> https://api.creem.io (production), 1 -> https://test-api.creem.io
+    this.creem = new Creem({
+      serverIdx: isTruthy(env.CREEM_TEST_MODE) ? 1 : 0,
+    })
+  }
+
+  async createCheckout(options: CheckoutOptions): Promise<CheckoutResult> {
+    const { plan, successUrl, userId, email } = options
+
+    const prices = getPriceConfig(plan, 'creem')
+    if (prices.length === 0) {
+      throw new Error(`No Creem prices configured for plan: ${plan}`)
+    }
+
+    // Use the monthly price if present, otherwise the first configured price.
+    const price = prices.find((p: any) => p.interval === 'month') || prices[0]
+
+    if (!price.productId) {
+      throw new Error(`No Creem product ID configured for plan ${plan}`)
+    }
+
+    try {
+      const checkout = await this.creem.createCheckout({
+        xApiKey: this.apiKey,
+        createCheckoutRequest: {
+          productId: price.productId,
+          successUrl: successUrl || paymentConfig.providers.successUrl,
+          ...(email && { customer: { email } }),
+          metadata: {
+            userId,
+            plan,
+            provider: 'creem',
+          },
+        },
+      })
+
+      if (!checkout.checkoutUrl) {
+        throw new Error('Creem checkout did not return a checkout URL')
+      }
+
+      return {
+        url: checkout.checkoutUrl,
+        sessionId: checkout.id,
+      }
+    } catch (error) {
+      console.error('Creem checkout creation error:', error)
+      throw new Error('Failed to create Creem checkout session')
+    }
+  }
+
+  async createCustomer(userId: string, email?: string): Promise<CustomerData> {
+    // Creem creates customers during checkout; there is no email-based lookup.
+    // Return a placeholder that the webhook will reconcile with the real id.
+    const customerId = `creem_pending_${userId}`
+
+    return {
+      id: customerId,
+      providerCustomerId: customerId,
+      email,
+      userId,
+      provider: 'creem',
+    }
+  }
+
+  async getSubscription(providerSubscriptionId: string): Promise<SubscriptionData | null> {
+    try {
+      const subscription = await this.creem.retrieveSubscription({
+        subscriptionId: providerSubscriptionId,
+        xApiKey: this.apiKey,
+      })
+
+      return this.mapSubscription(subscription)
+    } catch (error) {
+      console.error('Failed to get Creem subscription:', error)
+      return null
+    }
+  }
+
+  async cancelSubscription(providerSubscriptionId: string): Promise<void> {
+    try {
+      await this.creem.cancelSubscription({
+        id: providerSubscriptionId,
+        xApiKey: this.apiKey,
+      })
+    } catch (error) {
+      console.error('Creem subscription cancellation error:', error)
+      throw new Error('Failed to cancel Creem subscription')
+    }
+  }
+
+  async createPortal(customerId: string, _returnUrl?: string): Promise<PortalResult> {
+    const providerCustomerId = customerId.replace(/^creem_/, '')
+
+    try {
+      const links = await this.creem.generateCustomerLinks({
+        xApiKey: this.apiKey,
+        createCustomerPortalLinkRequestEntity: {
+          customerId: providerCustomerId,
+        },
+      })
+
+      return { url: links.customerPortalLink }
+    } catch (error) {
+      console.error('Creem portal creation error:', error)
+      throw new Error('Failed to create Creem customer portal session')
+    }
+  }
+
+  async processWebhook(event: WebhookEvent): Promise<WebhookResult> {
+    try {
+      const creemEvent = event.rawEvent as any
+      const eventType: string = creemEvent.eventType
+      const object = creemEvent.object || {}
+
+      switch (eventType) {
+        case 'checkout.completed': {
+          const userId = object.metadata?.userId || ''
+          const customerId = resolveId(object.customer)
+
+          // Recurring purchase: surface the subscription so it is persisted.
+          if (object.subscription) {
+            return {
+              processed: true,
+              subscription: this.mapSubscription(object.subscription, userId),
+            }
+          }
+
+          // One-time purchase: surface it as a payment.
+          if (object.order) {
+            const order = object.order
+            return {
+              processed: true,
+              payment: {
+                id: `creem_${resolveId(order)}`,
+                providerPaymentId: resolveId(order),
+                userId,
+                customerId: customerId ? `creem_${customerId}` : undefined,
+                type: 'one_time',
+                status: 'succeeded',
+                amount: typeof order.amount === 'number' ? order.amount : 0,
+                currency: order.currency || 'usd',
+                description: `Creem order ${resolveId(order)}`,
+                provider: 'creem',
+              },
+            }
+          }
+
+          return { processed: true }
+        }
+
+        case 'subscription.active':
+        case 'subscription.paid':
+        case 'subscription.trialing':
+        case 'subscription.update':
+        case 'subscription.past_due':
+        case 'subscription.unpaid':
+        case 'subscription.paused':
+        case 'subscription.canceled':
+        case 'subscription.expired': {
+          const userId = object.metadata?.userId || ''
+          return {
+            processed: true,
+            subscription: this.mapSubscription(object, userId),
+          }
+        }
+
+        default:
+          return { processed: true }
+      }
+    } catch (error) {
+      console.error('Creem webhook processing error:', error)
+      return {
+        processed: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }
+    }
+  }
+
+  async validateWebhook(rawBody: string, signature: string): Promise<boolean> {
+    if (!env.CREEM_WEBHOOK_SECRET) {
+      throw new Error('CREEM_WEBHOOK_SECRET is required for webhook validation')
+    }
+
+    const computed = crypto
+      .createHmac('sha256', env.CREEM_WEBHOOK_SECRET)
+      .update(rawBody)
+      .digest('hex')
+
+    const computedBuffer = Buffer.from(computed, 'utf8')
+    const signatureBuffer = Buffer.from(signature, 'utf8')
+
+    if (computedBuffer.length !== signatureBuffer.length) {
+      return false
+    }
+
+    return crypto.timingSafeEqual(computedBuffer, signatureBuffer)
+  }
+
+  /**
+   * Normalize a Creem subscription (from the API or a webhook payload) into the
+   * unified SubscriptionData shape. Accepts both camelCase (SDK) and snake_case
+   * (raw webhook) field names.
+   */
+  private mapSubscription(sub: any, userId = ''): SubscriptionData {
+    const productId = resolveId(sub.product)
+    const customerId = resolveId(sub.customer)
+    const plan = this.mapProductToPlan(productId)
+    const price = (getPriceConfig(plan, 'creem')[0] as any) || null
+
+    const currentPeriodStart =
+      toDate(sub.currentPeriodStartDate) || toDate(sub.current_period_start_date)
+    const currentPeriodEnd = toDate(sub.currentPeriodEndDate) || toDate(sub.current_period_end_date)
+    const canceledAt = toDate(sub.canceledAt) || toDate(sub.canceled_at)
+
+    return {
+      id: `creem_${resolveId(sub)}`,
+      providerSubscriptionId: resolveId(sub),
+      userId: userId || sub.metadata?.userId || '',
+      customerId: customerId ? `creem_${customerId}` : undefined,
+      status: this.mapStatus(sub.status),
+      plan,
+      provider: 'creem',
+      interval: price?.interval ?? 'month',
+      amount: price?.amount ?? null,
+      currency: price?.currency ?? null,
+      currentPeriodStart,
+      currentPeriodEnd,
+      cancelAtPeriodEnd: Boolean(canceledAt),
+      canceledAt,
+      trialStart: null,
+      trialEnd: null,
+    }
+  }
+
+  private mapStatus(status: string): SubscriptionData['status'] {
+    switch (status) {
+      case 'active':
+        return 'active'
+      case 'trialing':
+        return 'trialing'
+      case 'paused':
+        return 'paused'
+      case 'canceled':
+      case 'expired':
+        return 'canceled'
+      case 'past_due':
+      case 'unpaid':
+        return 'past_due'
+      default:
+        return 'incomplete'
+    }
+  }
+
+  private mapProductToPlan(productId: string): PlanName {
+    for (const [planName, plan] of Object.entries(paymentConfig.plans)) {
+      const creemPrices = (plan.prices as any).creem
+      if (creemPrices?.some((price: any) => price.productId === productId)) {
+        return planName as PlanName
+      }
+    }
+
+    return 'free'
+  }
+}

--- a/src/lib/payments/service.ts
+++ b/src/lib/payments/service.ts
@@ -11,6 +11,7 @@ import type { PaymentAdapter } from './types'
 import { StripeAdapter } from './providers/stripe'
 import { PolarAdapter } from './providers/polar'
 import { LemonSqueezyAdapter } from './providers/lemonsqueezy'
+import { CreemAdapter } from './providers/creem'
 
 // Singleton instance of the active adapter
 let paymentAdapter: PaymentAdapter | null = null
@@ -41,6 +42,9 @@ export function getPaymentAdapter(): PaymentAdapter {
       break
     case 'lemonsqueezy':
       paymentAdapter = new LemonSqueezyAdapter()
+      break
+    case 'creem':
+      paymentAdapter = new CreemAdapter()
       break
     default:
       throw new Error(`Unknown payment provider: ${provider}`)


### PR DESCRIPTION
Closes #31

Adds [Creem](https://creem.io) as a first-class payment provider alongside Stripe, Polar, and Lemon Squeezy. Creem is an EU-based Merchant of Record with low, transparent fees (as requested in the issue).

## What's included

- **`CreemAdapter`** (`src/lib/payments/providers/creem.ts`) implementing the full `PaymentAdapter` interface:
  - `createCheckout` — uses the `creem` SDK with our `userId`/`plan` metadata
  - `getSubscription` / `cancelSubscription`
  - `createPortal` — via Creem customer links (`customerPortalLink`)
  - `processWebhook` — maps `checkout.completed` + all `subscription.*` events to the unified subscription/payment shapes
  - `validateWebhook` — HMAC-SHA256 of the raw body, constant-time compared against the `creem-signature` header
- Registered `creem` in the payment service switch and the `PAYMENT_PROVIDER` union
- Plan config slots for Creem product IDs (starter/pro/enterprise)
- Env vars: `CREEM_API_KEY`, `CREEM_WEBHOOK_SECRET`, `CREEM_TEST_MODE`, and `NEXT_PUBLIC_CREEM_PRODUCT_*`
- `isCreemConfigured` feature flag (folded into `hasBillingProvider`)
- Webhook route now routes the `creem-signature` header and `eventType` parsing
- Docs + `.env.example` updated (providers, webhooks, environment)

The `creem` SDK and `@creem_io/better-auth` were already present in `package.json`.

## Notes / config

Creem uses **separate API keys for test and production**. Set `CREEM_TEST_MODE=true` to target `test-api.creem.io`.

## Verification

- `bun run typecheck` ✅
- `bunx biome lint` / `format` ✅ on the changed files (LF-normalized; repo `core.autocrlf` makes the local working copy CRLF)
- Not runtime-tested against the live Creem API (no credentials available in this environment); the adapter mirrors the existing provider adapters' structure and the official `creem` SDK types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)